### PR TITLE
Add SiliconFlow API support

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ nano .env
 | `HF_TOKEN`           | Pull/push models from 🤗 Hub        |
 | `WANDB_API_KEY`      | Weights & Biases logging (optional) |
 | `OPENROUTER_API_KEY` | Optional: for LLMs via OpenRouter   |
+| `SILICONFLOW_API_KEY`| Optional: for LLMs via SiliconFlow  |
 
 ---
 
@@ -151,7 +152,7 @@ lighteval vllm \
 ├── src/
 │   ├── classroom.py          # 🧠 Core RL loop (multi-agent dialog)
 │   ├── grpo/                 # GRPO reinforcement learning trainer
-│   ├── inference_providers/  # OpenRouter / Gemini adapters
+│   ├── inference_providers/  # OpenRouter / Gemini / SiliconFlow adapters
 │   └── vllm/                 # vLLM helpers (multi-node, memory mgmt)
 ├── utils/                    # reward functions, judge filters, logging
 ├── train_rl.py               # Entry point for RL training

--- a/README.md
+++ b/README.md
@@ -77,6 +77,9 @@ nano .env
 | `OPENROUTER_API_KEY` | Optional: for LLMs via OpenRouter   |
 | `SILICONFLOW_API_KEY`| Optional: for LLMs via SiliconFlow  |
 
+To run models through SiliconFlow, set `use_siliconflow: true` in the
+corresponding config section and provide the SiliconFlow model name.
+
 ---
 
 ## 🎓 Training

--- a/config/train_rl/7b.yaml
+++ b/config/train_rl/7b.yaml
@@ -8,6 +8,8 @@ train:
 
 teacher_model:
   model_name_or_path: Qwen/Qwen2.5-7B-Instruct
+  # The tutor must run locally so its weights can be updated
+  use_siliconflow: false
   vllm:
     temperature: 1.0
     max_length: 12000
@@ -21,6 +23,7 @@ teacher_model:
 
 student_model:
   model_name_or_path: neuralmagic/Meta-Llama-3.1-8B-Instruct-FP8
+  use_siliconflow: true
   vllm:
     temperature: 0.6
     max_length: 12000
@@ -34,6 +37,7 @@ student_model:
 
 judge_model:
   model_name_or_path: Qwen/Qwen2.5-14B-Instruct-AWQ
+  use_siliconflow: true
   vllm:
     temperature: 0.6
     max_length: 12000
@@ -46,6 +50,7 @@ judge_model:
 
 reward_model:
   model_name_or_path: Answer # If we set this to None we get the -r_sol run.
+  use_siliconflow: false
 
 huggingface:
   name: <huggingface_name>

--- a/config/train_rl_model.py
+++ b/config/train_rl_model.py
@@ -42,6 +42,7 @@ class TeacherModelConfig:
     model_name_or_path: str = "Qwen/Qwen2.5-7B-Instruct"
     use_openrouter: bool = False
     use_gemini: bool = False
+    use_siliconflow: bool = False
     vllm: ModelvLLMConfig = field(default_factory=ModelvLLMConfig)
     lora: LoraConfig = field(default_factory=LoraConfig)
 
@@ -51,6 +52,7 @@ class StudentModelConfig:
     model_name_or_path: str = "neuralmagic/Meta-Llama-3.1-8B-Instruct-FP8"
     use_openrouter: bool = False
     use_gemini: bool = False
+    use_siliconflow: bool = False
     vllm: ModelvLLMConfig = field(default_factory=ModelvLLMConfig)
 
 
@@ -59,12 +61,14 @@ class JudgeModelConfig:
     model_name_or_path: str = "Qwen/Qwen2.5-14B-Instruct-AWQ"
     use_openrouter: bool = False
     use_gemini: bool = False
+    use_siliconflow: bool = False
     vllm: ModelvLLMConfig = field(default_factory=ModelvLLMConfig)
 
 
 @dataclass
 class RewardModelConfig:
     model_name_or_path: str = "Qwen/Qwen2.5-Math-RM-72B"
+    use_siliconflow: bool = False
     vllm: ModelvLLMConfig = field(default_factory=ModelvLLMConfig)
 
 

--- a/src/classroom.py
+++ b/src/classroom.py
@@ -28,6 +28,7 @@ from src.vllm.data_parallel_vllm import ParallelvLLMInference, InferenceTask
 from src.utils.utils import check_equal, extract_answer
 from src.inference_providers.open_router_inference import OpenRouterInference
 from src.inference_providers.gemini_api_inference import GeminiInference
+from src.inference_providers.siliconflow_inference import SiliconFlowInference
 import logging
 
 logger = logging.getLogger(__name__)
@@ -610,7 +611,11 @@ class Classroom:
         self.reward_model_cfg = reward_model_cfg
         self.generation_cfg = generation_cfg
 
-        if self.teacher_model_cfg.use_openrouter:
+        if self.teacher_model_cfg.use_siliconflow:
+            self.teacher_model = SiliconFlowInference(
+                self.teacher_model_cfg.model_name_or_path
+            )
+        elif self.teacher_model_cfg.use_openrouter:
             self.teacher_model = OpenRouterInference(
                 self.teacher_model_cfg.model_name_or_path
             )
@@ -639,7 +644,11 @@ class Classroom:
             )
         self.teacher_model.sleep()
 
-        if self.student_model_cfg.use_openrouter:
+        if self.student_model_cfg.use_siliconflow:
+            self.student_model = SiliconFlowInference(
+                self.student_model_cfg.model_name_or_path
+            )
+        elif self.student_model_cfg.use_openrouter:
             self.student_model = OpenRouterInference(
                 self.student_model_cfg.model_name_or_path
             )
@@ -667,7 +676,11 @@ class Classroom:
             )
         self.student_model.sleep()
 
-        if self.judge_model_cfg.use_openrouter:
+        if self.judge_model_cfg.use_siliconflow:
+            self.judge_model = SiliconFlowInference(
+                self.judge_model_cfg.model_name_or_path
+            )
+        elif self.judge_model_cfg.use_openrouter:
             self.judge_model = OpenRouterInference(
                 self.judge_model_cfg.model_name_or_path
             )
@@ -693,7 +706,11 @@ class Classroom:
             )
         self.judge_model.sleep()
 
-        if self.reward_model_cfg.model_name_or_path not in ["None", "Answer"]:
+        if self.reward_model_cfg.use_siliconflow:
+            self.reward_model = SiliconFlowInference(
+                self.reward_model_cfg.model_name_or_path
+            )
+        elif self.reward_model_cfg.model_name_or_path not in ["None", "Answer"]:
             self.reward_model = ParallelvLLMInference(
                 model_path=reward_model_cfg.model_name_or_path,
                 gpus_per_instance=reward_model_cfg.vllm.number_of_gpus_per_instance,

--- a/src/inference_providers/siliconflow_inference.py
+++ b/src/inference_providers/siliconflow_inference.py
@@ -1,0 +1,98 @@
+################################################################
+# Simple Inference class for SiliconFlow API
+################################################################
+
+import os
+import time
+import random
+import concurrent.futures
+from openai import OpenAI
+from openai.types.chat import ChatCompletion
+from vllm import SamplingParams, RequestOutput, CompletionOutput
+from src.utils.utils import init_logger
+logger = init_logger()
+
+class SiliconFlowInference:
+    def __init__(self, model_name: str):
+        self.model_name = model_name
+        initial_api_key = os.getenv("SILICONFLOW_API_KEY")
+        self.client = OpenAI(
+            base_url="https://api.siliconflow.cn/v1",
+            api_key=initial_api_key,
+        )
+
+    def create_client(self, api_key: str):
+        client = OpenAI(
+            base_url="https://api.siliconflow.cn/v1",
+            api_key=api_key,
+        )
+        return client
+
+    def run_batch(self, conversations: list, sampling_params: SamplingParams, meta=None):
+        def _execute_one(conversation):
+            max_retries = 100000
+            backoff = 1
+            current_api_key = os.getenv("SILICONFLOW_API_KEY")
+            for attempt in range(1, max_retries + 1):
+                try:
+                    client = self.create_client(current_api_key)
+                    completion_outputs: list[CompletionOutput] = []
+                    for i in range(sampling_params.n):
+                        completion: ChatCompletion = client.chat.completions.create(
+                            model=self.model_name,
+                            messages=conversation,
+                            temperature=sampling_params.temperature,
+                            max_tokens=sampling_params.max_tokens,
+                            top_p=sampling_params.top_p,
+                        )
+                        completion_outputs.append(
+                            CompletionOutput(
+                                index=i,
+                                text=completion.choices[0].message.content,
+                                token_ids=completion.choices[0].message.content,
+                                cumulative_logprob=0.0,
+                                logprobs=[],
+                            )
+                        )
+
+                    req_out = RequestOutput(
+                        request_id="",
+                        prompt="",
+                        outputs=completion_outputs,
+                        prompt_token_ids=[],
+                        prompt_logprobs=[],
+                        finished=True,
+                    )
+                    logger.info(f"Attempt {attempt} succeeded")
+                    return req_out
+                except Exception as e:
+                    logger.warning(f"Attempt {attempt} failed for conversation: {e}")
+                    if attempt < max_retries:
+                        time.sleep(backoff)
+                        backoff *= 2
+                        if backoff > 30:
+                            backoff = 30
+                        jitter = random.uniform(0, 5)
+                        time.sleep(jitter)
+
+                        fallback_keys = [k for k in os.environ.keys() if k.startswith("SILICONFLOW_API_KEY")]
+                        if fallback_keys:
+                            fallback_key = random.choice(fallback_keys)
+                            logger.warning("Switching to fallback API key")
+                            current_api_key = os.getenv(fallback_key)
+                    else:
+                        logger.warning(f"All attempts failed for conversation {conversation}")
+                        return None
+
+        request_outputs = []
+        with concurrent.futures.ThreadPoolExecutor(max_workers=80) as executor:
+            futures = [executor.submit(_execute_one, conversation) for conversation in conversations]
+            for future in futures:
+                result = future.result()
+                if result is None:
+                    logger.warning("One of the requests failed after all retries.")
+                request_outputs.append(result)
+        return request_outputs
+
+    def sleep(self):
+        pass


### PR DESCRIPTION
## Summary
- add SiliconFlowInference adapter for using SiliconFlow API
- allow models to use SiliconFlow via new `use_siliconflow` flag
- select SiliconFlow backend in classroom when enabled
- document `SILICONFLOW_API_KEY` env var

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6860f689a3188333b31d1ae7645d7729